### PR TITLE
feat: add userinfo endpoint

### DIFF
--- a/pkg/providers/util/claim_extractor.go
+++ b/pkg/providers/util/claim_extractor.go
@@ -36,7 +36,6 @@ func NewClaimExtractor(idToken string, profileURL *url.URL, profileRequestHeader
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse ID Token payload: %v", err)
 	}
-
 	return &claimExtractor{
 		profileURL:     profileURL,
 		requestHeaders: profileRequestHeaders,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Currently, OIDC Plugin does not provide a /userinfo endpoint to retrieve login user information, similar to how [OAuth2-Proxy](https://github.com/oauth2-proxy/oauth2-proxy) does. This makes it difficult to obtain user details after authentication, which is essential for certain integrations and user session handling.

## Motivation and Context
feat: https://github.com/alibaba/higress/issues/1920
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
TODO
![image](https://github.com/user-attachments/assets/1f161882-7fee-4ae1-b599-fd64f481ae94)

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [ ] I have created a feature (non-master) branch for my PR.
- [ ] I have written tests for my code changes.
