### PR TITLE
fix bug of oidc refresh token internal service error 503

### DIFF
--- a/pkg/middleware/stored_session.go
+++ b/pkg/middleware/stored_session.go
@@ -208,11 +208,15 @@ func needsRefresh(refreshPeriod time.Duration, session *sessionsapi.SessionState
 func (s *StoredSessionLoader) refreshSession(rw http.ResponseWriter, req *http.Request, session *sessionsapi.SessionState, callback func(args ...interface{})) error {
 	refreshedCallBack := func(args ...interface{}) {
 		session := args[0].(*sessionsapi.SessionState)
-		session.CreatedAtNow()
-		// Because the session was refreshed, make sure to save it
-		err := s.store.Save(rw, req, session)
-		if err != nil {
-			util.Logger.Errorf("error saving session: %v", err)
+		if session != nil {
+			session.CreatedAtNow()
+			// Because the session was refreshed, make sure to save it
+			err := s.store.Save(rw, req, session)
+			if err != nil {
+				util.Logger.Errorf("error saving session: %v", err)
+			}
+		} else {
+			util.Logger.Warnf("session is nil, not saving")
 		}
 	}
 	combinedCallBack := util.Combine(refreshedCallBack, callback)

--- a/providers/aliyun.go
+++ b/providers/aliyun.go
@@ -121,7 +121,7 @@ func (p *AliyunProvider) redeemRefreshToken(ctx context.Context, s *sessions.Ses
 		token, err := util.UnmarshalToken(responseHeaders, responseBody)
 		if err != nil {
 			util.Logger.Errorf("unable to unmarshal token: %v", err)
-			callback(nil, false)
+			callback((*sessions.SessionState)(nil), false)
 			return
 		}
 		s.AccessToken = token.AccessToken

--- a/providers/aliyun.go
+++ b/providers/aliyun.go
@@ -120,7 +120,8 @@ func (p *AliyunProvider) redeemRefreshToken(ctx context.Context, s *sessions.Ses
 	client.Post(p.RedeemURL.String(), headers, []byte(params.Encode()), func(statusCode int, responseHeaders http.Header, responseBody []byte) {
 		token, err := util.UnmarshalToken(responseHeaders, responseBody)
 		if err != nil {
-			util.SendError(err.Error(), nil, http.StatusInternalServerError)
+			util.Logger.Errorf("unable to unmarshal token: %v", err)
+			callback(nil, false)
 			return
 		}
 		s.AccessToken = token.AccessToken

--- a/providers/oidc.go
+++ b/providers/oidc.go
@@ -167,7 +167,7 @@ func (p *OIDCProvider) redeemRefreshToken(ctx context.Context, s *sessions.Sessi
 		token, err := util.UnmarshalToken(responseHeaders, responseBody)
 		if err != nil {
 			util.Logger.Errorf("unable to unmarshal token: %v", err)
-			callback(nil, false)
+			callback((*sessions.SessionState)(nil), false)
 			return
 		}
 		redeemRefreshCallBack := func(args ...interface{}) {

--- a/providers/oidc.go
+++ b/providers/oidc.go
@@ -166,7 +166,8 @@ func (p *OIDCProvider) redeemRefreshToken(ctx context.Context, s *sessions.Sessi
 	client.Post(p.RedeemURL.String(), headers, []byte(params.Encode()), func(statusCode int, responseHeaders http.Header, responseBody []byte) {
 		token, err := util.UnmarshalToken(responseHeaders, responseBody)
 		if err != nil {
-			util.SendError(err.Error(), nil, http.StatusInternalServerError)
+			util.Logger.Errorf("unable to unmarshal token: %v", err)
+			callback(nil, false)
 			return
 		}
 		redeemRefreshCallBack := func(args ...interface{}) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
设置 refresh token 的过期时间短于 _oauth2_proxy cookie的 refresh时间，在 refresh token过期后再访问会出现503问题
https://github.com/alibaba/higress/issues/1761
<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [ ] I have created a feature (non-master) branch for my PR.
- [ ] I have written tests for my code changes.
