### PR TITLE
fix: nil panic in NewVerifierFromConfig and UpdateKeys callbacks

### DIFF
--- a/pkg/providers/go_oidc/jwks.go
+++ b/pkg/providers/go_oidc/jwks.go
@@ -150,7 +150,10 @@ func (r *RemoteKeySet) UpdateKeys(client wrapper.HttpClient, timeout uint32, cal
 			util.Logger.Errorf("RemoteKeySet UpdateKeys http call failed, status: %d", statusCode)
 			return
 		}
-		json.Unmarshal(responseBody, &keySet)
+		if err := json.Unmarshal(responseBody, &keySet); err != nil {
+			util.Logger.Errorf("RemoteKeySet UpdateKeys failed to unmarshal jwks response: %v", err)
+			return
+		}
 		r.cachedKeys = keySet.Keys
 		callback(true)
 	}, timeout)

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -71,8 +71,15 @@ func NewVerifierFromConfig(providerConfig options.Provider, p *ProviderData, cli
 				pkgutil.Logger.Errorf("openid-configuration http call failed, status: %d", statusCode)
 				return
 			}
-			json.Unmarshal(responseBody, &providerJson)
-			pv, _ := internaloidc.NewProviderVerifier(context.TODO(), verifierOptions, providerJson)
+			if err := json.Unmarshal(responseBody, &providerJson); err != nil {
+				pkgutil.Logger.Errorf("failed to unmarshal openid-configuration response: %v", err)
+				return
+			}
+			pv, err := internaloidc.NewProviderVerifier(context.TODO(), verifierOptions, providerJson)
+			if err != nil {
+				pkgutil.Logger.Errorf("failed to create provider verifier: %v", err)
+				return
+			}
 			p.Verifier = pv.Verifier()
 			if pv.DiscoveryEnabled() {
 				// Use the discovered values rather than any specified values


### PR DESCRIPTION
## Summary

- Fix nil pointer panic in `NewVerifierFromConfig` callback: `json.Unmarshal` and `NewProviderVerifier` errors were silently discarded, causing `pv.Verifier()` to panic when `pv` is nil (e.g. issuer mismatch, malformed JSON response)
- Fix silent failure in `RemoteKeySet.UpdateKeys`: `json.Unmarshal` error was ignored, which could clear cached JWKS keys on malformed responses

## Root Cause

Online panic trace:
```
runtime.nilPanic → providers.NewVerifierFromConfig$1 → wrapper.HttpCall$1 → proxy_on_http_call_response
```

In `NewVerifierFromConfig`, the OIDC discovery callback had:
```go
json.Unmarshal(responseBody, &providerJson)          // error ignored
pv, _ := internaloidc.NewProviderVerifier(...)       // error ignored, pv can be nil
p.Verifier = pv.Verifier()                          // nil panic
```

## Fix

Check errors and return early with logging in both callbacks. The existing `ValidateVerifier()` + `SetVerifier` tick mechanism ensures automatic retry on next interval.

## Test plan

- [x] `go build ./...` passes
- [ ] Deploy with issuer URL mismatch scenario — verify error log instead of panic
- [ ] Deploy with malformed JWKS endpoint — verify keys are not silently cleared

🤖 Generated with [Claude Code](https://claude.com/claude-code)