### PR TITLE
fix: send each Set-Cookie as separate header during session refresh

### DIFF
--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -466,9 +466,8 @@ func (p *OAuthProxy) Proxy(rw http.ResponseWriter, req *http.Request) {
 			util.Logger.Debug("X-Forwarded-Access-Token header add access token")
 		}
 		if cookies, ok := rw.Header()[SetCookieHeader]; ok && len(cookies) > 0 {
-			newCookieValue := strings.Join(cookies, ",")
 			if p.ctx != nil {
-				p.ctx.SetContext(SetCookieHeader, newCookieValue)
+				p.ctx.SetContext(SetCookieHeader, cookies)
 				util.Logger.Info("Authentication and session refresh successfully .")
 			} else {
 				util.Logger.Error("Set Cookie failed cause HttpContext is nil.")
@@ -490,9 +489,12 @@ func (p *OAuthProxy) Proxy(rw http.ResponseWriter, req *http.Request) {
 	case errors.Is(err, ErrAccessDenied):
 		util.Logger.Debug("Access denied due to authorization checks")
 		if cookies, ok := rw.Header()[SetCookieHeader]; ok && len(cookies) > 0 {
-			newCookieValue := strings.Join(cookies, ",")
 			errorMsg := "The session failed authorization checks. clear the cookie"
-			proxywasm.SendHttpResponseWithDetail(http.StatusForbidden, errorMsg, [][2]string{{SetCookieHeader, newCookieValue}}, []byte(http.StatusText(http.StatusForbidden)), -1)
+			headers := make([][2]string, len(cookies))
+			for i, c := range cookies {
+				headers[i] = [2]string{SetCookieHeader, c}
+			}
+			proxywasm.SendHttpResponseWithDetail(http.StatusForbidden, errorMsg, headers, []byte(http.StatusText(http.StatusForbidden)), -1)
 		} else {
 			util.SendError("The session failed authorization checks", rw, http.StatusForbidden)
 		}


### PR DESCRIPTION
## Summary

- Fix session refresh failure caused by comma-joining multiple `Set-Cookie` headers into a single header value
- `Set-Cookie` is the only HTTP header that cannot be comma-folded (RFC 6265), because the `Expires` attribute contains commas (e.g. `Thu, 05 Jun 2026 09:10:07 GMT`)
- Browsers silently discard the malformed `Set-Cookie`, so the refreshed session cookie is never saved. The next request carries the stale cookie → `No valid authentication` → SSO redirect
- The login path (`redirectToLocation`) already handles this correctly by emitting each `Set-Cookie` as a separate header; this fix aligns the refresh path to the same behavior

## Root Cause

In `Proxy()`, after a successful session refresh:

```go
// Before (broken): comma-joins multiple Set-Cookie values
newCookieValue := strings.Join(cookies, ",")
p.ctx.SetContext(SetCookieHeader, newCookieValue)

// After (fixed): stores []string, each cookie written as independent header
p.ctx.SetContext(SetCookieHeader, cookies)
```

The WASM plugin (`main.go`) then needs to iterate and call `AddHttpResponseHeader` once per cookie instead of once for the joined string.

> **Note:** This bug only triggers when the session cookie exceeds 4KB (split into `_oauth2_proxy_0`, `_oauth2_proxy_1`, ...) or when stale cookie shards need cleanup — producing 2+ `Set-Cookie` entries. Sessions under 4KB with no shard changes are unaffected, which is why the bug is intermittent.

## Companion Change

The OIDC WASM plugin (`higress/plugins/wasm-go/extensions/oidc/main.go`) also needs a corresponding update to read `[]string` instead of `string` from the context:

```go
// Before
proxywasm.AddHttpResponseHeader(oidc.SetCookieHeader, value.(string))

// After
if cookies, ok := value.([]string); ok {
    for _, c := range cookies {
        proxywasm.AddHttpResponseHeader(oidc.SetCookieHeader, c)
    }
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)